### PR TITLE
Correct typo preventing connection

### DIFF
--- a/lib/ws-client.js
+++ b/lib/ws-client.js
@@ -190,7 +190,7 @@ wsClient.prototype.stopScanning = function(){
 wsClient.prototype.connect = function(peripheralId){
   this.sendAction({
     action : 'connect',
-    perihperalId : peripheralId
+    peripheralId : peripheralId
   })
 }
 


### PR DESCRIPTION
When attempting a connection using the `connect()` function of `ws-client.js`, the following message was sent to `ws-slave.js` which provoked a crash:
```
ws -> message: {"action":"connect","perihperalId":"70********2c"}
```